### PR TITLE
Crowd Debug and Incorrect Lose Message bugs

### DIFF
--- a/Assets/OurFiles/Scripts/Contracts/Contract.cs
+++ b/Assets/OurFiles/Scripts/Contracts/Contract.cs
@@ -122,6 +122,8 @@ public class Contract : Singleton<Contract>
 
     void LoseGame(State loseCondition)
     {
+        if (currentState != State.PLAYING) return;
+
         currentState = loseCondition;
         SceneLoader.Instance.LoadScene(loseScene);
     }

--- a/Assets/OurFiles/Scripts/Contracts/LostGameDisplay.cs
+++ b/Assets/OurFiles/Scripts/Contracts/LostGameDisplay.cs
@@ -17,6 +17,7 @@ public class LostGameDisplay : MonoBehaviour
     void Start()
     {
         SetReason();
+
         Contract.Instance.EndContract();
     }
 

--- a/Assets/OurFiles/Scripts/Editor/CrowdDebug.cs
+++ b/Assets/OurFiles/Scripts/Editor/CrowdDebug.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using System.Collections.Generic;
+using UnityEditor.Experimental.GraphView;
 
 
 //Base written by: Rohan Anakin
@@ -43,7 +44,7 @@ public class CrowdDebug : EditorWindow
 
             if (spawner != null && spawner.Target != null)
             {
-                MeshRenderer targetMesh = spawner.Target.GetComponent<MeshRenderer>();
+                LOD[] lods = spawner.Target.GetComponentInChildren<LODGroup>().GetLODs();
 
                 if (GUILayout.Button("Enable Debug Target Visual"))
                 {
@@ -54,14 +55,14 @@ public class CrowdDebug : EditorWindow
                     }
                     if (targetOriginalMaterial == null)
                     {
-                        targetOriginalMaterial = targetMesh.material;
+                        targetOriginalMaterial = lods[0].renderers[0].material;
                     }
 
-                    targetMesh.material = targetDebugMaterial;
+                    SetMaterial(lods, targetDebugMaterial);
                 }
                 if (GUILayout.Button("Disable Debug Target Visual"))
                 {
-                    targetMesh.material = targetOriginalMaterial;
+                    SetMaterial(lods, targetOriginalMaterial);
                 }
             }
             else
@@ -72,6 +73,14 @@ public class CrowdDebug : EditorWindow
         else
         {
             GUILayout.Label("Enter Play Mode to see more options", EditorStyles.boldLabel); //this is to stop any scary destruction of objects that could cause catastrophy
+        }
+    }
+
+    private void SetMaterial(LOD[] lods, Material material)
+    {
+        foreach (LOD lod in lods)
+        {
+            lod.renderers[0].material = material;
         }
     }
 }


### PR DESCRIPTION
**Changes**
* Fixed bug where target debugger tool (which made the target red) didn't work. It should now go red when you click.
* Fixed bug where sometimes you would get the wrong message on the lose screen.

**How To test**
* Check if you can highlight the target via the `Crowd Debugger` inside of the `Tools` dropdown.
* Lose the game and see if the message corresponds to how you lost. (this was not broken every time so test a couple times)

**How to merge**
All changes were in code, so just merge the branch.

Closes #85 
Closes #86 