### PR TITLE
Follower Null Reference Fix

### DIFF
--- a/Assets/OurFiles/Scripts/NPC/Behaviours/Leader.cs
+++ b/Assets/OurFiles/Scripts/NPC/Behaviours/Leader.cs
@@ -81,7 +81,7 @@ public class Leader : Crowd
     {
         for (int i = 0; i < followers.Count; i++)
         {
-            followers[i].GetComponent<VisionBehaviour>().Suspicion = 100f;
+            followers[i].GetComponentInChildren<VisionBehaviour>().Suspicion = 100f;
             followers[i].GoToExitScene(GetNewRandomGoal());
         }
     }


### PR DESCRIPTION
**Changes**
 * Changed Leader to use `GetComponentInChildren<VisionBehaviour>` instead of `GetComponent<VisionBehaviour>` on death for setting followers to panic.
 
**How to merge**
Just click merge, all changes were done in code.

Closes #101