### PR TITLE
Pushback misbehaving fix

### DIFF
--- a/Assets/OurFiles/Prefabs/Resources/NPC.prefab
+++ b/Assets/OurFiles/Prefabs/Resources/NPC.prefab
@@ -423,6 +423,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: VisionCone
       objectReference: {fileID: 0}
+    - target: {fileID: 1434067162573427333, guid: a2b5228496654974cbdf53fb84a3b0f1, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 3769951644288241368, guid: a2b5228496654974cbdf53fb84a3b0f1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0

--- a/Assets/OurFiles/Scripts/Player/XRPushbackProvider.cs
+++ b/Assets/OurFiles/Scripts/Player/XRPushbackProvider.cs
@@ -6,6 +6,7 @@ using UnityEngine.XR.Interaction.Toolkit.Locomotion;
 // base 'written' by Joshii
 // lots of code yoinked from ContinuousMoveProvider
 // head collision detection algorithm discovered from this tutorial:
+// XR Interaction Toolkit v3.0?
 //   https://www.youtube.com/watch?v=FVPnp3fTGnw
 public class XRPushbackProvider : LocomotionProvider
 {
@@ -29,11 +30,8 @@ public class XRPushbackProvider : LocomotionProvider
         Vector3 motion = pushbackStrength * Time.deltaTime * direction;
 
         TryStartLocomotionImmediately();
-        if (locomotionState == LocomotionState.Moving)
-        {
-            Transformation.motion = motion;
-            TryQueueTransformation(Transformation);
-        }
+        Transformation.motion = motion;
+        TryQueueTransformation(Transformation);
     }
 
     private void FindCharacterController()
@@ -55,7 +53,7 @@ public class XRPushbackProvider : LocomotionProvider
         List<RaycastHit> newDetectedHits = new();
 
         List<Vector3> directions = new() { origin.forward, origin.right, -origin.right };
-        
+
         RaycastHit hit;
         foreach (Vector3 direction in directions)
         {


### PR DESCRIPTION
# Issue
> **Describe the bug**
> The player randomly moves when no inputs are given to the game.
> This is caused by the `Pushback` Locomotion on the player.
> It is extremely obvious when the player is in an enclosed space like the elevator.

Closes #99

# Changes
- Set NPC vision cone layer to "NPC" (cones were causing pushback to push back)
- Removed some unnecessary code from pushback script

# File locations
**XRPushbackProvider:** *OurFiles/Scripts/*
**Vision cone:** *OurFiles/Prefabs/Resources/NPC.prefab*